### PR TITLE
Added environment variables for database user and password

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -4,8 +4,8 @@
 # Stop on error
 set -e
 
-SUPER_USER=super
-SUPER_PASS=$(pwgen -s -1 16)
+SUPER_USER=${USER:-super}
+SUPER_PASS=${PASSWORD:-$(pwgen -s -1 16)}
 DATA_DIR=/data
 MYSQL_LOG=$DATA_DIR/mysql.log
 


### PR DESCRIPTION
Added optional environment variables `USER` and `PASSWORD` to specify user and password used for the database upon running the container. This is very useful when linking containers to each other:

First start the database container (I'll name it `sql`):

``` bash
docker run -d -name sql -e PASSWORD=(pwgen -s -1 16) -e USER=admin niclashoyer/mariadb
```

Then spin up another container with a link (`sql` linked as `db`):

``` bash
docker run -t -i -link sql:db ubuntu bash
```

Using the environment variables it is now possible to connect to the database container using the provided password:

``` bash
apt-get install -y mysql-client
mysql -u "$DB_ENV_USER" -p"$DB_ENV_PASSWORD" -h "$DB_PORT_3306_TCP_ADDR" -P "$DB_PORT_3306_TCP_PORT"
```
