### PR TITLE
Wait for database to finish before starting up again

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -50,7 +50,13 @@ mysql -u root -e "$(cat << EOF
 EOF
 )"
 
-kill $(cat /run/mysqld/mysqld.pid)
+PID=$(cat /run/mysqld/mysqld.pid)
+
+kill $PID
+
+while [[ ( -d /proc/$PID ) && ( -z `grep zombie /proc/$PID/status` ) ]]; do
+    sleep 1
+done
 
 # Start MariaDB
 echo "Starting MariaDB..."


### PR DESCRIPTION
I got problems running the container, because `mysqld` needs too long to finish after it is killed in `start.sh`:

```
[...]
Starting MariaDB...
140105 10:25:13 mysqld_safe Logging to '/data/mysql.log'.
140105 10:25:13 mysqld_safe A mysqld process already exists
```

I added a loop that waits until the `mysqld` process really exited. The loop is based upon [this answer](http://stackoverflow.com/questions/1058047/wait-for-any-process-to-finish/11719943#11719943) on stackoverflow.
