### PR TITLE
Remove leftover sockets before starting mysql

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -25,6 +25,9 @@ fi
 chown -R mysql $DATA_DIR
 chown root $DATA_DIR/debian*.flag
 
+# Remove any leftover sockets from previous runs
+rm -f /run/mysqld/mysqld.sock
+
 /usr/bin/mysqld_safe --skip-syslog --log-error=$MYSQL_LOG >> /dev/null &
 
 # Wait for mysql to finish starting up first.


### PR DESCRIPTION
From my testing, #4 is due to leftover sockets being left after an unclean shutdown of the server.
Removing the socket before starting mysql seems to fix the issue.
